### PR TITLE
Homogenize account usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
 MUMBAI_RPC_URL="https://rpc-mumbai.maticvigil.com/"
 MUMBAI_POLYGONSCAN_API_URL="https://api-testnet.polygonscan.com/"
-# Get this from https://polygonscan.com/myapikey - Polyscan's mainnet API key works for mumbai too.
+# Get this from https://polygonscan.com/myapikey - mainnet APIs key works for testnets too.
 MUMBAI_POLYGONSCAN_API_KEY=""
-# Example taken from Hardhat's default accounts
-MUMBAI_DEPLOYER_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-MUMBAI_DEPLOYER_ADDRESS="0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+# Get it from https://fractal.1password.com/vaults/xgtlkpabgydcxef3fupe4soe64/allitems/ik5vilni3fxfklrxcs4igaxbvy
+MUMBAI_DEPLOYER_PRIVATE_KEY=""
+MUMBAI_DEPLOYER_ADDRESS="0x89f3648B47cD32d7A861241C84ad887d04E118bC"
 
 POLYGON_RPC_URL="https://polygon-rpc.com"
 POLYGON_POLYGONSCAN_API_URL="https://api.polygonscan.com/"
@@ -16,7 +16,7 @@ POLYGON_DEPLOYER_ADDRESS="0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
 
 GOERLI_RPC_URL="https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
 GOERLI_ETHERSCAN_API_URL="https://api-goerli.etherscan.io/"
-# Get this from https://etherscan.com/myapikey
+# Get this from https://etherscan.com/myapikey - mainnet APIs key works for testnets too.
 GOERLI_ETHERSCAN_API_KEY=""
 # Get it from https://fractal.1password.com/vaults/xgtlkpabgydcxef3fupe4soe64/allitems/ik5vilni3fxfklrxcs4igaxbvy
 GOERLI_DEPLOYER_PRIVATE_KEY=""
@@ -24,7 +24,7 @@ GOERLI_DEPLOYER_ADDRESS="0x89f3648B47cD32d7A861241C84ad887d04E118bC"
 
 FUJI_RPC_URL="https://api.avax-test.network/ext/bc/C/rpc"
 FUJI_ETHERSCAN_API_URL="https://api-testnet.snowtrace.io"
-# Get this from https://snowtrace.io/myapikey
+# Get this from https://snowtrace.io/myapikey - mainnet APIs key works for testnets too.
 FUJI_ETHERSCAN_API_KEY=""
 # Get it from https://fractal.1password.com/vaults/xgtlkpabgydcxef3fupe4soe64/allitems/ik5vilni3fxfklrxcs4igaxbvy
 FUJI_DEPLOYER_PRIVATE_KEY=""
@@ -40,7 +40,7 @@ AVALANCHE_DEPLOYER_ADDRESS="0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
 
 CHAPEL_RPC_URL="https://data-seed-prebsc-1-s1.binance.org:8545/"
 CHAPEL_ETHERSCAN_API_URL="https://api-testnet.bscscan.com/"
-# Get this from https://bscscan.com/myapikey
+# Get this from https://bscscan.com/myapikey - mainnet APIs key works for testnets too.
 CHAPEL_ETHERSCAN_API_KEY=""
 # Get it from https://fractal.1password.com/vaults/xgtlkpabgydcxef3fupe4soe64/allitems/ik5vilni3fxfklrxcs4igaxbvy
 CHAPEL_DEPLOYER_PRIVATE_KEY=""


### PR DESCRIPTION
I was getting a bit confused of when to use the testnet deployer account we have on 1P, and when we should have a proper deployer key. The only one which wasn't coherent was Mumbai, so I changed it.

Does this change make sense for you?